### PR TITLE
Refactor blacklist feature with new stage

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -25,6 +25,9 @@ DEFAULT_CONFIG = {
         "id_whitelist_log": True,
         "wl_ignore_admin_on_group": True,
         "wl_ignore_admin_on_friend": True,
+        "enable_id_black_list": False,
+        "id_blacklist": [],
+        "id_blacklist_log": True,
         "reply_with_mention": False,
         "reply_with_quote": False,
         "path_mapping": [],
@@ -225,7 +228,7 @@ CONFIG_METADATA_2 = {
                         "telegram_command_auto_refresh": True,
                         "telegram_command_register_interval": 300,
                     },
-                    "discord":{
+                    "discord": {
                         "id": "discord",
                         "type": "discord",
                         "enable": False,
@@ -364,15 +367,15 @@ CONFIG_METADATA_2 = {
                         "hint": "请务必填对，否则 @ 机器人将无法唤醒，只能通过前缀唤醒。",
                         "obvious_hint": True,
                     },
-                    "discord_token":{
+                    "discord_token": {
                         "description": "Discord Bot Token",
                         "type": "string",
-                        "hint": "在此处填入你的Discord Bot Token"
+                        "hint": "在此处填入你的Discord Bot Token",
                     },
-                    "discord_proxy":{
+                    "discord_proxy": {
                         "description": "Discord 代理地址",
                         "type": "string",
-                        "hint": "可选的代理地址：http://ip:port"
+                        "hint": "可选的代理地址：http://ip:port",
                     },
                 },
             },
@@ -505,6 +508,22 @@ CONFIG_METADATA_2 = {
                         "description": "打印白名单日志",
                         "type": "bool",
                         "hint": "启用后，当一条消息没通过白名单时，会输出 INFO 级别的日志。",
+                    },
+                    "enable_id_black_list": {
+                        "description": "启用 ID 黑名单",
+                        "type": "bool",
+                    },
+                    "id_blacklist": {
+                        "description": "ID 黑名单",
+                        "type": "list",
+                        "items": {"type": "string"},
+                        "obvious_hint": True,
+                        "hint": "填写的 ID 的消息会被忽略，可使用 /bl 添加黑名单",
+                    },
+                    "id_blacklist_log": {
+                        "description": "打印黑名单日志",
+                        "type": "bool",
+                        "hint": "启用后，当一条消息在黑名单中时，会输出 INFO 级别的日志。",
                     },
                     "wl_ignore_admin_on_group": {
                         "description": "管理员群组消息无视 ID 白名单",

--- a/astrbot/core/pipeline/__init__.py
+++ b/astrbot/core/pipeline/__init__.py
@@ -4,6 +4,7 @@ from astrbot.core.message.message_event_result import (
 )
 
 from .waking_check.stage import WakingCheckStage
+from .blacklist_check.stage import BlacklistCheckStage
 from .whitelist_check.stage import WhitelistCheckStage
 from .rate_limit_check.stage import RateLimitStage
 from .content_safety_check.stage import ContentSafetyCheckStage
@@ -16,6 +17,7 @@ from .respond.stage import RespondStage
 # 管道阶段顺序
 STAGES_ORDER = [
     "WakingCheckStage",  # 检查是否需要唤醒
+    "BlacklistCheckStage",  # 检查黑名单
     "WhitelistCheckStage",  # 检查是否在群聊/私聊白名单
     "RateLimitStage",  # 检查会话是否超过频率限制
     "ContentSafetyCheckStage",  # 检查内容安全
@@ -28,6 +30,7 @@ STAGES_ORDER = [
 
 __all__ = [
     "WakingCheckStage",
+    "BlacklistCheckStage",
     "WhitelistCheckStage",
     "RateLimitStage",
     "ContentSafetyCheckStage",

--- a/astrbot/core/pipeline/blacklist_check/stage.py
+++ b/astrbot/core/pipeline/blacklist_check/stage.py
@@ -1,0 +1,34 @@
+from ..stage import Stage, register_stage
+from ..context import PipelineContext
+from typing import AsyncGenerator, Union
+from astrbot.core.platform.astr_message_event import AstrMessageEvent
+from astrbot.core import logger
+
+
+@register_stage
+class BlacklistCheckStage(Stage):
+    """检查是否在会话或用户黑名单中"""
+
+    async def initialize(self, ctx: PipelineContext) -> None:
+        ps = ctx.astrbot_config["platform_settings"]
+        self.enable_blacklist = ps.get("enable_id_black_list", False)
+        self.blacklist = [str(i).strip() for i in ps.get("id_blacklist", []) if str(i).strip() != ""]
+        self.bl_log = ps.get("id_blacklist_log", True)
+
+    async def process(
+        self, event: AstrMessageEvent
+    ) -> Union[None, AsyncGenerator[None, None]]:
+        if not self.enable_blacklist:
+            return
+        sender = str(event.get_sender_id()).strip()
+        group_id = str(event.get_group_id()).strip()
+        if (
+            event.unified_msg_origin in self.blacklist
+            or sender in self.blacklist
+            or group_id in self.blacklist
+        ):
+            if self.bl_log:
+                logger.info(
+                    f"会话 ID {event.unified_msg_origin} 在会话黑名单中，已终止事件传播。"
+                )
+            event.stop_event()

--- a/packages/astrbot/main.py
+++ b/packages/astrbot/main.py
@@ -417,6 +417,47 @@ UID: {user_id} 此 ID 可用于设置管理员。
             event.set_result(MessageEventResult().message("此 SID 不在白名单内。"))
 
     @filter.permission_type(filter.PermissionType.ADMIN)
+    @filter.command("bl")
+    async def bl(self, event: AstrMessageEvent, uid: str = None):
+        """管理黑名单。bl <uid>|list"""
+        config = self.context.get_config()["platform_settings"]
+        if uid is None:
+            event.set_result(
+                MessageEventResult().message(
+                    "使用方法: /bl <id> 添加黑名单；/dbl <id> 删除黑名单；/bl list 查看黑名单。可通过 /sid 获取 ID。"
+                )
+            )
+            return
+
+        if uid == "list":
+            bl = config.get("id_blacklist", [])
+            msg = "黑名单：\n" + "\n".join(bl) if bl else "黑名单为空。"
+            event.set_result(MessageEventResult().message(msg))
+            return
+
+        uid = str(uid)
+        bl = config.setdefault("id_blacklist", [])
+        if uid in bl:
+            event.set_result(MessageEventResult().message("该 ID 已在黑名单中。"))
+            return
+        bl.append(uid)
+        self.context.get_config().save_config()
+        event.set_result(MessageEventResult().message("添加黑名单成功。"))
+
+    @filter.permission_type(filter.PermissionType.ADMIN)
+    @filter.command("dbl")
+    async def dbl(self, event: AstrMessageEvent, uid: str):
+        """删除黑名单。dbl <uid>"""
+        try:
+            self.context.get_config()["platform_settings"]["id_blacklist"].remove(
+                str(uid)
+            )
+            self.context.get_config().save_config()
+            event.set_result(MessageEventResult().message("删除黑名单成功。"))
+        except ValueError:
+            event.set_result(MessageEventResult().message("此 ID 不在黑名单内。"))
+
+    @filter.permission_type(filter.PermissionType.ADMIN)
     @filter.command("provider")
     async def provider(
         self, event: AstrMessageEvent, idx: Union[str, int] = None, idx2: int = None


### PR DESCRIPTION
## Summary
- move blacklist logic into new `BlacklistCheckStage`
- restore `WhitelistCheckStage` to whitelist-only checks
- enhance `/bl` command with duplicate check and list functionality
- update pipeline order and tests for blacklist cases

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'quart')*

------
https://chatgpt.com/codex/tasks/task_b_685777d3d07c83228b2e37b68a2827bd